### PR TITLE
Fixes #6 canvas editing GUI didn't work for Igor and later

### DIFF
--- a/CanvasElement.php
+++ b/CanvasElement.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Class CanvasElement
+ *
+ * A custom element used for DokuWiki "Igor" and later, where old JavaScript injection won't work anymore.
+ *
+ * This is not a general-purpose element. It is strictly designed for sketchcanvas plugin.
+ */
+class CanvasElement extends dokuwiki\Form\InputElement
+{
+    /**
+     * @var string the actual text within the area
+     */
+    protected $text;
+
+    /**
+     * @param string $name The name of this form element
+     * @param string $label The label text for this element
+     */
+    public function __construct()
+    {
+        parent::__construct('canvas', 'canvas', '');
+    }
+
+        /**
+     * Get or set the element's value
+     *
+     * This is the preferred way of setting the element's value
+     *
+     * @param null|string $value
+     * @return string|$this
+     */
+    public function val($value = null)
+    {
+        if ($value !== null) {
+            $this->text = $value;
+            return $this;
+        }
+        return $this->text;
+    }
+
+    /**
+     * The HTML representation of this element
+     *
+     * @return string
+     */
+    protected function mainElementHTML()
+    {
+        $escText = '"' . str_replace(array("\r", "\n"), array('\r', '\n'), addslashes($this->text)) . '"';
+
+        $attrs = buildAttributes($this->attrs());
+
+        $canvasText = <<<EOT
+<canvas id="editcanvas" $attrs></canvas>
+<script type="text/javascript"><!--
+var skcanvas;
+document.addEventListener('DOMContentLoaded', function(){
+    skcanvas = new SketchCanvas(document.getElementById('editcanvas'), {editmode: true});
+    skcanvas.loadData($escText);
+    skcanvas.onUpdateData = function(data){
+        var wikitext = document.getElementById('wiki__text');
+        wikitext.value = data;
+    }
+});
+--></script>
+<input type="button" value="Load data from text" onclick="skcanvas.loadData(document.getElementById('wiki__text').value)">
+<textarea name="wikitext" id="wiki__text" class="edit" cols="80" rows="10">$this->text</textarea>
+EOT;
+        return $canvasText;
+    }
+
+}

--- a/action.php
+++ b/action.php
@@ -9,6 +9,8 @@
 // must be run within Dokuwiki
 if (!defined('DOKU_INC')) die();
 
+require_once("CanvasElement.php");
+
 /**
  * Add scripts via an event handler
  */
@@ -22,6 +24,8 @@ class action_plugin_sketchcanvas extends DokuWiki_Action_Plugin {
 
        $controller->register_hook('HTML_SECEDIT_BUTTON', 'BEFORE', $this, 'editButton');
        $controller->register_hook('HTML_EDIT_FORMSELECTION', 'BEFORE', $this, 'editForm');
+       // After Igor
+       $controller->register_hook('EDIT_FORM_ADDTEXTAREA', 'BEFORE', $this, 'editFormNew');
        $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'handle_newfigure');
 
        $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'toolbarDefine');
@@ -112,6 +116,32 @@ document.addEventListener('DOMContentLoaded', function(){
 <textarea name="wikitext" id="wiki__text" class="edit" cols="80" rows="10">$TEXT</textarea>
 EOT;
         $form->addElement($canvasText);
+
+        // Pass wikitext through POSTs for previewing and saving
+        if(isset($_POST['editfigure__new'])) {
+            foreach($_POST['editfigure__new'] as $k => $v) {
+                $form->addHidden("editfigure__new[$k]", $v);
+            }
+        }
+    }
+
+    /**
+     * A
+     *
+     * @param Doku_Event $event
+     */
+    public function editFormNew(Doku_Event $event, $param){
+        global $TEXT;
+        if($event->data['target'] !== 'plugin_sketchcanvas')
+            return;
+        $event->preventDefault();
+
+        $event->data['media_manager'] = false;
+
+        $form =& $event->data['form'];
+        $canvasElem = new CanvasElement();
+        $canvasElem->val($TEXT);
+        $form->addElement($canvasElem);
 
         // Pass wikitext through POSTs for previewing and saving
         if(isset($_POST['editfigure__new'])) {


### PR DESCRIPTION
Fixes #6, SketchCanvas editor GUI stopped working since Igor, due to some changes in the way forms are handled.
Specifically, these changes were incompatible:

* `HTML_EDIT_FORMSELECTION` event is not invoked anymore.
* New `EDIT_FORM_ADDTEXTAREA` event uses a new `Form` class instead of `Doku_Form`, which completely changes API.

Previously, we injected a canvas and its accopanying small JavaScript code to synchronize the text area and the canvas. However it is no longer possible to directly inject text into the output HTML. We need a specific implementation of `Element` class.

In order to keep backwards compatibility, `HTML_EDIT_FORMSELECTION` was left intact, and added a new `EDIT_FORM_ADDTEXTAREA` handler with the custom `CanvasElement` class.

Tested on:
* [x] Igor
* [x] “Jack Jackrum”
* [x] “Hogfather”
* [x] “Greebo”