### PR TITLE
Fix new figures cannot be edited

### DIFF
--- a/action.php
+++ b/action.php
@@ -224,7 +224,8 @@ EOT;
                 // not sure if/how this would happen, we restore all data and hand over to section edit
                 $INPUT->post->set('target', 'section');
                 $TEXT = $fields['pre'].$fields['text'].$fields['suf'];
-                $ACT  = 'edit';
+                $INPUT->post->set('wikitext', $TEXT);
+                $event->data  = 'edit';
                 break;
             case 'save':
                 // return to edit page

--- a/action.php
+++ b/action.php
@@ -126,7 +126,7 @@ EOT;
         // Pass wikitext through POSTs for previewing and saving
         if(isset($_POST['editfigure__new'])) {
             foreach($_POST['editfigure__new'] as $k => $v) {
-                $form->setHiddenField("editfigure__new[$k]", $v);
+                $form->addHidden("editfigure__new[$k]", $v);
             }
         }
     }

--- a/action.php
+++ b/action.php
@@ -126,7 +126,7 @@ EOT;
         // Pass wikitext through POSTs for previewing and saving
         if(isset($_POST['editfigure__new'])) {
             foreach($_POST['editfigure__new'] as $k => $v) {
-                $form->addHidden("editfigure__new[$k]", $v);
+                $form->setHiddenField("editfigure__new[$k]", $v);
             }
         }
     }
@@ -152,7 +152,7 @@ EOT;
         // Pass wikitext through POSTs for previewing and saving
         if(isset($_POST['editfigure__new'])) {
             foreach($_POST['editfigure__new'] as $k => $v) {
-                $form->addHidden("editfigure__new[$k]", $v);
+                $form->setHiddenField("editfigure__new[$k]", $v);
             }
         }
     }
@@ -230,6 +230,7 @@ EOT;
                 // return to edit page
                 $INPUT->post->set('target', 'section');
                 $TEXT = $fields['pre']."<skcanvas>\n".$TEXT."</skcanvas>".$fields['suf'];
+                $INPUT->post->set('wikitext', $TEXT);
                 $ACT  = 'edit';
                 break;
         }


### PR DESCRIPTION
# Issue

Edit a page and insert a new canvas with this button:

![image](https://github.com/msakuta/SketchCanvas/assets/2798715/436335b3-7da4-404f-8d47-f255b1cd2d2b)

Shows this error:

![image](https://github.com/msakuta/SketchCanvas/assets/2798715/48fef4eb-ce47-474c-b7cf-b426b6587685)

Using the edit button at the bottom of a figure works fine.

![image](https://github.com/msakuta/SketchCanvas/assets/2798715/0cd7bada-b878-4765-863b-0659fb46b951)

It happens in all versions through Igor to Kaos, but since it only happens in new figures, it hasn't been spotted.

# Cause

The name of the method `Form::addHidden` has changed to `Form::setHiddenField`. _Why did you do this to me [again](https://github.com/msakuta/SketchCanvas/pull/7#issue-2069036116)_?

But it was not the only problem. After renaming the function, I can edit the figure all I want:

![image](https://github.com/msakuta/SketchCanvas/assets/2798715/b0b57f06-513a-435c-8eb7-473352abeaf2)

but when I click save, the entire document text is replaced by the canvas source:

![image](https://github.com/msakuta/SketchCanvas/assets/2798715/173e2867-62dc-4315-a356-62d3902c30e6)

which is supposed to keep the other parts of the document preserved like below:

![image](https://github.com/msakuta/SketchCanvas/assets/2798715/530e3748-66cd-4f3a-8cf1-646d83f3bec8)

This issue is super weird, because I copied the original code from edittable plugin, which is one of the official plugins made by the DokuWiki team.

It turned out, writing into `$TEXT` global variable in `ACTION_ACT_PREPROCESS` event handler is not enough to make the text area to have the whole text.
The original text posted from the client was saved to `$INPUT->post` and the text area (abstracted as `TextareaElement`) will pull data from it.
It happened in this method in `dokuwiki/inc/Form/TextareaElement.php` (yes, I had to go through dokuwiki source code) when `InputElement::useInput` field is ture.

```php
    /**
     * The HTML representation of this element
     *
     * @return string
     */
    protected function mainElementHTML()
    {
        if ($this->useInput) $this->prefillInput();
        return '<textarea ' . buildAttributes($this->attrs()) . '>' .
            formText($this->val()) . '</textarea>';
    }
```

In this function, `prefillInput` method is called, which is defined as this in `dokuwiki/inc/Form/InputElement.php`.

```php
    /**
     * Handles the useInput flag and set the value attribute accordingly
     */
    protected function prefillInput()
    {
        global $INPUT;

        list($name, $key) = $this->getInputName();
        if (!$INPUT->has($name)) return;

        if ($key === null) {
            $value = $INPUT->str($name);
        } else {
            $value = $INPUT->arr($name);
            if (isset($value[$key])) {
                $value = $value[$key];
            } else {
                $value = '';
            }
        }
        $this->val($value);
    }
```

I'm still not entirely sure why you need `$TEXT` global variable when you have `$INPUT`.
The code is too cluttered with global variables that represent similar things. I mean, look at this in `Editor.php`:

```php
    public function show()
    {
        global $INPUT;
        global $ID;
        global $REV;
        global $DATE;
        global $PRE;
        global $SUF;
        global $INFO;
        global $SUM;
        global $lang;
        global $conf;
        global $TEXT;

        global $license;
```

I just gave up trying to understand the whole picture, just use a solution that seems to work.

# Another issue: cancelling partial editing SketchCanvas cancels all pages

When you enter SketchCanvas editor using the toolbar icon while already in a text editor, it will enter into a "nested" edit mode, just like edittable plugin. It works fine when you click Save or preivew.

However, canceling will cancel the parent edit session (text editor) and the whole text editing will be gone!
It is extremely annoying when you are editing a very long text and you lose all of them.

I remember it didn't behave like this before, probably in Hogfather, but now it does in Igor.

The most puzzling part is that edittable plugin doesn't behave like that (although it has another problem with Save button).

I found the difference. SketchCanvas writes to `$ACT` global variable like this:

```php
            case 'draftdel':
                // not sure if/how this would happen, we restore all data and hand over to section edit
                $INPUT->post->set('target', 'section');
                $TEXT = $fields['pre'].$fields['text'].$fields['suf'];
                $ACT  = 'edit';
                break;
```

while edittable does this (although I'm pretty sure it was also like above long time ago):

```php
            case 'draftdel':
                // not sure if/how this would happen, we restore all data and hand over to section edit
                $INPUT->post->set('target', 'section');
                $TEXT = $fields['pre'].$fields['text'].$fields['suf'];
                $event->data = 'edit';
                break;
```

## Logging for investigation

Since PHP services are responses to requests, it's hard to attach a debugger to the query I wanted to debug.
For this reason, loggings is still very helpful method.

Below is a debug log after I sprinkled tons of `\dokuwiki\Logger::debug()` logs with SketchCanvas when I clicked cancel from nested edit:

```
2024-05-20 14:49:05		sketchcanvas->handle_newfigure: ACT: edit data: edit
2024-05-20 14:49:07		checkUpdateMessages(): messages up to date
2024-05-20 14:49:07		sketchcanvas->handle_newfigure: ACT: cancel data: cancel
2024-05-20 14:49:07		sketchcanvas->handle_newfigure: ACT: draftdel data: draftdel
2024-05-20 14:49:07		Draftdel->preProcess: ACT: edit
2024-05-20 14:49:07		sketchcanvas->handle_newfigure: ACT: edit data: redirect
2024-05-20 14:49:07		Redirect->preProcess: ACT: edit
```

You can see draftdel action is converted to edit (which is intended), but it in turn converted to redirect action.

On the other hand, this is the log of edittable:

```
2024-05-20 14:49:32		edittable->handle_newtable ACT: edit data: edit
2024-05-20 14:49:34		checkUpdateMessages(): messages up to date
2024-05-20 14:49:34		edittable->handle_newtable ACT: cancel data: cancel
2024-05-20 14:49:34		edittable->handle_newtable ACT: draftdel data: draftdel
```

It does not redirect after draftdel action because it does not assign `edit` to `$ACT` but to `$event->data`.
Now, the next question is, what is the difference between `$ACT` and `$event->data`.
I have no idea whatsoever.


## The effect of editing `$ACT` or `$event->data`

This section is my speculation by observing how edittable works.

First, the key event is `ACTION_ACT_PREPROCESS`. As written in [the documentation](https://www.dokuwiki.org/devel:event:action_act_preprocess), it is an event called before an action is dispatched.
"Dispatch" is a concept in DokuWiki that maps actions to corresponding pages and edit forms through `ActionRouter` class.

By rewriting `$ACT`, it can work as a map to the input action. In our case, we want to map the edit action to edittable or sketchcanvas figures, except that it's not working as we expect.

When the action was `cancel`, we want to map it to `edit` and inject the edited contents from nested edit session.
It had been working with Hogfather, but this subtle behavior changes in ActionRouter broke us.

Specifically, see this first part of `ActionRouter::setupAction`:

```php
    protected function setupAction(&$actionname) {
        $presetup = $actionname;

        try {
            // give plugins an opportunity to process the actionname
            $evt = new Extension\Event('ACTION_ACT_PREPROCESS', $actionname);
            if ($evt->advise_before()) {
                $this->action = $this->loadAction($actionname);
                $this->checkAction($this->action);
                $this->action->preProcess();
            } else {
                // event said the action should be kept, assume action plugin will handle it later
                $this->action = new Plugin($actionname);
            }
            $evt->advise_after();

        } catch(ActionException $e) {
```

First, it saves original `$actionname` which is in this case `cancel`.
Then it sends `ACTION_ACT_PREPROCESS` event and edittable or SketchCanvas plugin will rewrite the action to `edit`.
However, it uses previously saved `$presetup = $actionname` to load an action, which is `Cancel` action.

Now, let's see how `Cancel` is implemented:

```php
class Cancel extends AbstractAliasAction {
    /**
     * @inheritdoc
     * @throws ActionAbort
     */
    public function preProcess() {
        global $ID;
        unlock($ID);

        // continue with draftdel -> redirect -> show
        throw new ActionAbort('draftdel');
    }
}
```

It raises an exception! The conversion of the action happens here, overwriting our even handler!

Let's go back to `ActionRouter::setupAction` and how the exception is handled.
Now it calls `$this->transitionAction` with the new action name, which is `draftdel`.

```php
        } catch(ActionException $e) {
            // we should have gotten a new action
            $actionname = $e->getNewAction();

            // ...

            // do setup for new action
            $this->transitionAction($presetup, $actionname);

        } catch(NoActionException $e) {
```

I can imagine what is supposed to happen. It should delete the draft, although it's entirely unnecessary for our plugin, because we don't actually make a draft document, just a nested edit form.

Anyway, let's see how it's handled in `$this->transitionAction`.
Surprise! It is a recursion to `setupAction`! Now it repeats with `draftdel` action.

```php
    protected function transitionAction($from, $to, $e = null) {
        // ...

        // do the recursion
        $this->setupAction($to);
    }
```

And how `Draftdel` class looks like? Of course it returns redirect.

```php
class Draftdel extends AbstractAction {
    public function preProcess() {
        // ...
        throw new ActionAbort('redirect');
    }
}
```

So what makes difference in edittable? It seems assigning `$ACT` does not make difference anymore, but `$event->data` is a shared state through reference which can alter the behavior of ActionRouter.
Incidentally, `ActionRouter::setupAction` has a curious docstring.

```
     * @param string $actionname this is passed as a reference to $ACT, for plugin backward compatibility
```

Although it does not make much sense by itself, it suggests that the extensions need to write into `$event->data` in `ACTION_ACT_PREPROCESS` event handler, but it also try to be backwards compatible by using a reference to `$ACT` (which seems not successful?)

It seems edittable plugin has fixed in [this PR](https://github.com/cosmocode/edittable/pull/146) which unfortunately doesn't give any context.

Now I think I understand. When `setupAction` is called for the first time, it takes a reference to global `$ACT` as a reference. The reference is called `$actionname`.

```
$ACT(='cancel') <- &$actionname
```

When the `Cancel` action is invoked and an exception is raised, it calls `transitionAction` and make a copy of value referenced by `$actionname`, in this case it's `$ACT`.
In the text below, first digit indicate stack frame, most recent call first.

```
0 $actionname(='draftdel') <- &$actionname
1 $ACT(='cancel') <- &$actionname
```

Now, when the `ACTION_ACT_PREPROCESS` event handler is called, it's supposed to overwrite the top of the stack, so that the resulting action is `edit`.

```
0 $actionname(='edit') <- &$actionname
1 $ACT(='cancel') <- &$actionname
```

However, because SketchCanvas was written for old DokuWiki version, it directly wrote to `$ACT`, which makes this:

```
0 $actionname(='draftdel') <- &$actionname
1 $ACT(='edit') <- &$actionname
```

and it in turn transfer to `redirect` via an exception in `Draftdel` action.

It didn't surface in other actions because it only exposes if the action transition through exception layers more than 2.

At this point I think it's a bug in DokuWiki that `transitionAction` should take a reference to previous stack frame, but I'm not very sure since there is no specification.


# The solution

First, we need to replace `addHidden` with `setHiddenField`.

```diff
@@ -152,7 +152,7 @@ EOT;
         // Pass wikitext through POSTs for previewing and saving
         if(isset($_POST['editfigure__new'])) {
             foreach($_POST['editfigure__new'] as $k => $v) {
-                $form->addHidden("editfigure__new[$k]", $v);
+                $form->setHiddenField("editfigure__new[$k]", $v);
             }
         }
     }
```

And we replace the original data `$INPUT->post` with updated `$TEXT`.
It may affect other code that assumes `$INPUT` was not altered, but I don't see any issue for now.

```diff
             case 'save':
                 // return to edit page
                 $input->post->set('target', 'section');
                 $text = $fields['pre']."<skcanvas>\n".$text."</skcanvas>".$fields['suf'];
+                $INPUT->post->set('wikitext', $TEXT);
                 $ACT  = 'edit';
```

In order to fix the cancel bug, we can simply replace `$ACT` with `$event->data`. And of course, I had to set `$INPUT->post` with the concatenated text to keep context. _Why?_

```diff
             case 'draftdel':
                 // not sure if/how this would happen, we restore all data and hand over to section edit
                 $INPUT->post->set('target', 'section');
                 $TEXT = $fields['pre'].$fields['text'].$fields['suf'];
-                $ACT = 'edit';
+                $INPUT->post->set('wikitext', $TEXT);
+                $event->data = 'edit';
                 break;
```

# Tests

* ~“Greebo”~ too old to run on PHP7
* [x] “Hogfather”
* [x] Igor
* [x] “Jack Jackrum”
* [x] Kaos

# Afterthought

It seems unnecessarily complex to fix such a simple bug! This was caused by the excessive use of global variables, unclear responsibility boundary and casual breaking changes.

It is the longest PR description I've ever written for 5 lines of changes!

Here are some of my thoughts about the DokuWiki code organization.

* They should not use recursion to process action transfers. Recursion adds stack memory and more room for unexpected states that causes bugs. They could have used loops instead, in which case variables won't stack up as iteration happens.
* They should avoid using global variables. PHP uses `$_REQUEST` and other global variables, but they could restrain themselves from adding more.
* They should be clear about the interface specification. The interface is not only event handler API but also the global variables which can be used to communicate between the main application and plugins. It is a part of the interface in a larger scope. However, the interface contract was unclear, so I could not know which are stable and which are bound to break.
* They should have respected backward compatibility. Since there is no clear specificatoin of the interface, _everything visible is the interface_. Any change to the semantics of the global variables (like this issue) is bound to break some plugin. The only way to keep compatibility more stable is to reduce the observable interface as small as possible, but it's difficult to achieve with PHP.
* They should have compatibility resolution mechanism. Right now, the users have to download plugins from each author's download links, but they are a single link and there is no way to resolve the version of the plugin that is compatible with the plugin version. Plugin versions are not managed to begin with, so it is impossible afterwards, but we could have semantic versioning. If we did, I could have made 2 versions for old and new DokuWiki installations instead of keeping backward compatibiliy magic code.
* They should not have used PHP to begin with, although I know there were not many other options back in 2006...
